### PR TITLE
refactor: Save swaps according to its network

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "typecheck": "tsc"
   },
   "dependencies": {
-    "@ponder/core": "^0.4.7",
+    "@ponder/core": "^0.4.24",
     "alchemy-sdk": "^3.1.2",
     "viem": "^1.19.3"
   },

--- a/ponder.config.ts
+++ b/ponder.config.ts
@@ -23,8 +23,8 @@ export default createConfig({
           startBlock: 5719042,
         },
         // kakarot: {
-        //   address: "0x11FA19B071faB6E119dBefFfaa23eFb79F14f4A2",
-        //   startBlock: 3394,
+        //   address: "0xB317127b50b22e62637E3c333A585a8ccfd0721D",
+        //   startBlock: 90,
         // },
       },
     },

--- a/ponder.config.ts
+++ b/ponder.config.ts
@@ -22,10 +22,10 @@ export default createConfig({
           address: "0xFA682bcE8b1dff8D948aAE9f0fBade82D28E1842",
           startBlock: 5719042,
         },
-        // kakarot: {
-        //   address: "0xB317127b50b22e62637E3c333A585a8ccfd0721D",
-        //   startBlock: 90,
-        // },
+        kakarot: {
+          address: "0xB317127b50b22e62637E3c333A585a8ccfd0721D",
+          startBlock: 90,
+        },
       },
     },
   },

--- a/ponder.schema.ts
+++ b/ponder.schema.ts
@@ -7,6 +7,7 @@ export default createSchema((p) => ({
     blockTimestamp: p.bigint(),
     transactionHash: p.hex(),
     status: p.enum("StatusSwaps"),
+    network: p.bigint(),
     swapId: p.bigint(),
     owner: p.hex(),
     allowed: p.hex(),

--- a/src/Swaplace.ts
+++ b/src/Swaplace.ts
@@ -3,7 +3,6 @@ import { getSwapData } from "./getSwap";
 //import { getEnsData } from "./getEns";
 import { getTokenData } from "./getToken";
 import { Swap, Token } from "./types";
-import { createConfig } from "@ponder/core";
 
 ponder.on("Swaplace:SwapCreated", async ({ event, context }) => {
   const { client } = context;

--- a/src/Swaplace.ts
+++ b/src/Swaplace.ts
@@ -1,8 +1,9 @@
 import { ponder } from "@/generated";
 import { getSwapData } from "./getSwap";
-import { getEnsData } from "./getEns";
+//import { getEnsData } from "./getEns";
 import { getTokenData } from "./getToken";
 import { Swap, Token } from "./types";
+import { createConfig } from "@ponder/core";
 
 ponder.on("Swaplace:SwapCreated", async ({ event, context }) => {
   const { client } = context;
@@ -10,7 +11,7 @@ ponder.on("Swaplace:SwapCreated", async ({ event, context }) => {
   const {
     SwapDatabase,
     ProfileDatabase,
-    EnsDatabase,
+    //EnsDatabase,
     TokenDatabase,
     OverallDatabase,
   } = context.db;
@@ -65,6 +66,7 @@ ponder.on("Swaplace:SwapCreated", async ({ event, context }) => {
           blockTimestamp: event.block.timestamp,
           transactionHash: event.transaction.hash,
           status: "CREATED",
+          network: BigInt(context.network.chainId),
           swapId: swapId,
           owner: owner,
           allowed: swap.allowed,
@@ -214,6 +216,7 @@ ponder.on("Swaplace:SwapAccepted", async ({ event, context }) => {
           blockTimestamp: event.block.timestamp,
           transactionHash: event.transaction.hash,
           status: "ACCEPTED",
+          network: BigInt(context.network.chainId),
           swapId: swapId,
           owner: owner,
           allowed: swap.allowed,
@@ -280,7 +283,7 @@ ponder.on("Swaplace:SwapAccepted", async ({ event, context }) => {
           ensName: primaryName,
           acceptSwapCount: profile.acceptSwapCount + BigInt(1),
           totalTransactionCount: profile.totalTransactionCount + BigInt(1),
-          totalScore: profile.totalScore + BigInt(10), // How much should it increment/decrement?
+          totalScore: profile.totalScore + BigInt(10),
         },
       });
     }
@@ -310,6 +313,7 @@ ponder.on("Swaplace:SwapCanceled", async ({ event, context }) => {
           blockTimestamp: event.block.timestamp,
           transactionHash: event.transaction.hash,
           status: "CANCELED",
+          network: BigInt(context.network.chainId),
           swapId: swapId,
           owner: owner,
           allowed: swap.allowed,

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,7 +13,7 @@ export interface Client {
 
 export interface Swaplace {
   abi: any;
-  address: string;
+  address: any;
 }
 
 export interface Asset {


### PR DESCRIPTION
closes #38 

When changing networks the according events should be fetched and displayed due to the:

- [x] Addition of a `network` property in the ponder schema
- [x] Handling of this new property in the indexer functions, in `Swaplace.ts` 