### PR TITLE
fix: commented `kakarot` network to prevent bugs

### DIFF
--- a/ponder.config.ts
+++ b/ponder.config.ts
@@ -22,10 +22,10 @@ export default createConfig({
           address: "0xFA682bcE8b1dff8D948aAE9f0fBade82D28E1842",
           startBlock: 5719042,
         },
-        kakarot: {
-          address: "0xB317127b50b22e62637E3c333A585a8ccfd0721D",
-          startBlock: 90,
-        },
+        // kakarot: {
+        //   address: "0xB317127b50b22e62637E3c333A585a8ccfd0721D",
+        //   startBlock: 90,
+        // },
       },
     },
   },


### PR DESCRIPTION
Ponder fetches is bugging because of the `kakarot network` so I am commenting it for now.