### PR TITLE
feat: returning expiry as unixTimestmap

### DIFF
--- a/ponder.config.ts
+++ b/ponder.config.ts
@@ -9,10 +9,10 @@ export default createConfig({
       chainId: 11155111,
       transport: http(process.env.ALCHEMY_RPC_URL),
     },
-    kakarot: {
-      chainId: 1802203764,
-      transport: http(process.env.KAKAROT_RPC_URL),
-    },
+    // kakarot: {
+    //   chainId: 1802203764,
+    //   transport: http(process.env.KAKAROT_RPC_URL),
+    // },
   },
   contracts: {
     Swaplace: {

--- a/src/getSwap.ts
+++ b/src/getSwap.ts
@@ -17,9 +17,9 @@ export async function getSwapData(
     // Extracting the allowed address
     const allowed = (config >> BigInt(96)).toString(16);
 
-    // Extracting the expiry timestamp
-    const expiry: bigint =
-      BigInt(config) & ((BigInt(1) << BigInt(96)) - BigInt(1));
+    // Directly calculating the expiry timestamp
+    let expiry: bigint =
+      (config >> BigInt(64)) & ((BigInt(1) << BigInt(32)) - BigInt(1));
 
     // Extracting the recipient
     const recipient: bigint =


### PR DESCRIPTION
Returning the expiry as unixTimeStamp so it can be correctly fetched when using the ponder queries on the frontend.

closes #44 